### PR TITLE
Added the italian support

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,5 +145,10 @@ println(humanizer.humanize(22141000, options)) // 6 hours, 9 minutes and 1 secon
 Supported languages
 -------------------
 
-Duration Humanizer by default has only English support but soon I'll try to add other languages.
+Duration Humanizer by default has only English support.  
+If you want add more languages, you can include the following dependencies.
 
+**Note**. Replace `latest_version` with the latest humanizer version published: [![](https://jitpack.io/v/mirrajabi/duration-humanizer.svg)](https://jitpack.io/#mirrajabi/duration-humanizer)  
+
+* Italian  
+  `implementation com.github.mirrajabi:duration-humanizer-it:latest_version`

--- a/italian/build.gradle
+++ b/italian/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.21'
+}
+
+group 'nl.mirrajabi'
+version '1.0'
+
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    implementation project(':duration-humanizer')
+    
+    testImplementation 'junit:junit:4.12'
+}
+
+compileKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}
+compileTestKotlin {
+    kotlinOptions.jvmTarget = "1.8"
+}

--- a/italian/src/main/kotlin/nl/mirrajabi/humanize/duration/languages/ItalianDictionary.kt
+++ b/italian/src/main/kotlin/nl/mirrajabi/humanize/duration/languages/ItalianDictionary.kt
@@ -4,17 +4,6 @@ package nl.mirrajabi.humanize.duration.languages
  * Italian implementation of [LanguageDictionary].
  */
 class ItalianDictionary : LanguageDictionary {
-    private val words = mapOf(
-        DictionaryKeys.YEAR to "anno",
-        DictionaryKeys.MONTH to "month",
-        DictionaryKeys.WEEK to "week",
-        DictionaryKeys.DAY to "day",
-        DictionaryKeys.HOUR to "hour",
-        DictionaryKeys.MINUTE to "minute",
-        DictionaryKeys.SECOND to "second",
-        DictionaryKeys.MILLISECOND to "millisecond",
-        DictionaryKeys.DECIMAL to "."
-    )
 
     override fun provide(key: String, count: Double): String {
         val isPlural = count != 1.0

--- a/italian/src/main/kotlin/nl/mirrajabi/humanize/duration/languages/ItalianDictionary.kt
+++ b/italian/src/main/kotlin/nl/mirrajabi/humanize/duration/languages/ItalianDictionary.kt
@@ -1,0 +1,45 @@
+package nl.mirrajabi.humanize.duration.languages
+
+/**
+ * Italian implementation of [LanguageDictionary].
+ */
+class ItalianDictionary : LanguageDictionary {
+    private val words = mapOf(
+        DictionaryKeys.YEAR to "anno",
+        DictionaryKeys.MONTH to "month",
+        DictionaryKeys.WEEK to "week",
+        DictionaryKeys.DAY to "day",
+        DictionaryKeys.HOUR to "hour",
+        DictionaryKeys.MINUTE to "minute",
+        DictionaryKeys.SECOND to "second",
+        DictionaryKeys.MILLISECOND to "millisecond",
+        DictionaryKeys.DECIMAL to "."
+    )
+
+    override fun provide(key: String, count: Double): String {
+        val isPlural = count != 1.0
+
+        // Italian is strange :s we cannot infer a rule to consistently determine plural nouns
+        // We need to go manual then
+        return when {
+            key == DictionaryKeys.YEAR && isPlural -> "anni"
+            key == DictionaryKeys.YEAR -> "anno"
+            key == DictionaryKeys.MONTH && isPlural -> "mesi"
+            key == DictionaryKeys.MONTH -> "mese"
+            key == DictionaryKeys.WEEK && isPlural -> "settimane"
+            key == DictionaryKeys.WEEK -> "settimana"
+            key == DictionaryKeys.DAY && isPlural -> "giorni"
+            key == DictionaryKeys.DAY -> "giorno"
+            key == DictionaryKeys.HOUR && isPlural -> "ore"
+            key == DictionaryKeys.HOUR -> "ora"
+            key == DictionaryKeys.MINUTE && isPlural -> "minuti"
+            key == DictionaryKeys.MINUTE -> "minuto"
+            key == DictionaryKeys.SECOND && isPlural -> "secondi"
+            key == DictionaryKeys.SECOND -> "secondo"
+            key == DictionaryKeys.MILLISECOND && isPlural -> "millisecondi"
+            key == DictionaryKeys.MILLISECOND -> "millisecondo"
+            key == DictionaryKeys.DECIMAL -> ","
+            else -> throw UnsupportedOperationException("Invalid key $key")
+        }
+    }
+}

--- a/italian/src/test/kotlin/ItalianDictionaryTests.kt
+++ b/italian/src/test/kotlin/ItalianDictionaryTests.kt
@@ -1,0 +1,23 @@
+package nl.mirrajabi.humanize.duration.languages
+
+import nl.mirrajabi.humanize.duration.DurationHumanizer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tests for [ItalianDictionary].
+ */
+class ItalianDictionaryTests {
+
+    private val options = DurationHumanizer.Options(
+        language = "it",
+        languages = mapOf("it" to ItalianDictionary())
+    )
+    private val humanizer = DurationHumanizer()
+
+    @Test fun `README examples are properly humanized`() {
+        assertEquals("3 secondi", humanizer.humanize(3000, options))
+        assertEquals("2 secondi, 250 millisecondi", humanizer.humanize(2250, options))
+        assertEquals("1 giorno, 3 ore, 2 minuti", humanizer.humanize(97320000, options))
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,5 @@ rootProject.name = 'duration-humanizer'
 include 'lib'
 findProject(':lib')?.name = 'duration-humanizer'
 
+include 'italian'
+findProject(':italian')?.name = 'duration-humanizer-it'


### PR DESCRIPTION
This PR adds the italian language. 

The new artifact can be included as another dependency using the following line: 

```groovy
implementation com.github.mirrajabi:duration-humanizer-it:latest_version
```